### PR TITLE
ci: disable the iova field

### DIFF
--- a/.github/workflows/build-cn10k.yml
+++ b/.github/workflows/build-cn10k.yml
@@ -43,7 +43,7 @@ jobs:
           export CC='ccache gcc-14'
           echo "cache_dir = ~/.ccache" > ~/.ccache/ccache.conf
           ccache -p
-          meson build -Dexamples=all -Denable_drivers="*/cnxk,raw/cnxk_emdev,net/ring,net/tap" -Dplatform=cn10k --prefix="${PWD}/install"
+          meson build -Dexamples=all -Denable_drivers="*/cnxk,raw/cnxk_emdev,net/ring,net/tap" -Dplatform=cn10k -Denable_iova_as_pa=false --prefix="${PWD}/install"
           ninja install -C build
           sed -i "s/prefix=.*/prefix=/g" "${PWD}/install/lib/aarch64-linux-gnu/pkgconfig/libdpdk.pc"
           sed -i "s/prefix=.*/prefix=/g" "${PWD}/install/lib/aarch64-linux-gnu/pkgconfig/libdpdk-libs.pc"


### PR DESCRIPTION
Meson build option enable_iova_as_pa should be
set to false because on CNXK platforms,
IOVA is same as the virtual address.