### PR TITLE
ci: remove redundant git fetch

### DIFF
--- a/.github/workflows/build-cn10k.yml
+++ b/.github/workflows/build-cn10k.yml
@@ -44,7 +44,6 @@ jobs:
         run: |
           set -x
           mkdir -p "${PWD}/artifacts"
-          git fetch --tags --quiet
 
           EVENT="${{ github.event_name }}"
 


### PR DESCRIPTION
Remove redundant git fetch step
to fix Tag push builds.