### PR TITLE
ci: strip tvm/dmlc from .pc

### DIFF
--- a/.github/workflows/build-cn10k.yml
+++ b/.github/workflows/build-cn10k.yml
@@ -129,6 +129,9 @@ jobs:
           cp -av "${TVM_PREFIX}/lib/"libtvm_runtime.so* "${PWD}/install/lib/aarch64-linux-gnu/"
           sed -i "s/prefix=.*/prefix=/g" "${PWD}/install/lib/aarch64-linux-gnu/pkgconfig/libdpdk.pc"
           sed -i "s/prefix=.*/prefix=/g" "${PWD}/install/lib/aarch64-linux-gnu/pkgconfig/libdpdk-libs.pc"
+          for pc in libdpdk.pc libdpdk-libs.pc; do
+            sed -i 's/ -ldmlc//g' "${PWD}/install/lib/aarch64-linux-gnu/pkgconfig/${pc}"
+          done
           PKG_VERSION_NAME=`cat VERSION | awk -F'.' '{print $1"."$2}'`
           MRVL_PKG_VERSION=`cat MRVL_VERSION`
           DISTRO=ubuntu-`lsb_release -rs`


### PR DESCRIPTION
The ml/cnxk driver is built with TVM, which
causes DPDK to emit -ldmlc -ltvm_runtime.
Static consumers (DAO) are forced to link TVM/dmlc, breaking their build.
Strip both tokens during packaging.